### PR TITLE
Fix syntax error in installation advice

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -13,7 +13,7 @@ function MariaGenerator(args, options, config) {
   this.hookFor(this.testFramework, { as: 'app' });
 
   this.on('end', function () {
-    console.log('\nI\'m all done. Just run ' + 'npm install &; bower install'.bold.yellow + ' to install the required dependencies.');
+    console.log('\nI\'m all done. Just run ' + 'npm install & bower install'.bold.yellow + ' to install the required dependencies.');
   });
 
   this.pkg = JSON.parse(this.readFileAsString(path.join(__dirname, '../package.json')));


### PR DESCRIPTION
Sorry for that one. ;) I suggested that syntax once, but it only works in fish and throws an error in bash/zsh.
